### PR TITLE
Add a safe interface for jl_eval_string

### DIFF
--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -374,6 +374,8 @@ pub mod traits;
 pub mod util;
 pub mod value;
 
+pub use value::eval_string;
+
 use error::{JlrsError, JlrsResult};
 use frame::{DynamicFrame, NullFrame, StaticFrame};
 use global::Global;
@@ -636,7 +638,7 @@ impl CCall {
     /// same way as [`Julia::init`] does. This function must never be called outside a function
     /// called through `ccall` from Julia and must only be called once during that call. The stack
     /// is not allocated untl a static or dynamic frame is created.
-    /// 
+    ///
     /// [`Julia::init`]: struct.Julia.html#method.init
     pub unsafe fn new(stack_size: usize) -> Self {
         CCall {

--- a/jlrs/tests/eval_string.rs
+++ b/jlrs/tests/eval_string.rs
@@ -1,0 +1,56 @@
+use jlrs::prelude::*;
+use jlrs::util::JULIA;
+use jlrs::value::CallResult;
+
+fn eval_string(string: &str, with_result: impl for<'f> FnOnce(CallResult<'f, 'static>)) {
+    JULIA.with(|j| {
+        let mut jlrs = j.borrow_mut();
+        jlrs.frame(1, |global, frame| {
+            with_result(jlrs::eval_string(global, frame, string)?);
+            Ok(())
+        })
+        .unwrap();
+    });
+}
+
+#[test]
+fn basic_math() {
+    eval_string("Int32(2) + Int32(3)", |result| {
+        assert_eq!(result.unwrap().cast::<i32>().unwrap(), 5i32);
+    });
+}
+
+#[test]
+fn runtime_error() {
+    eval_string("[1, 2, 3][4]", |result| {
+        assert_eq!(result.unwrap_err().type_name(), "BoundsError");
+    });
+}
+
+#[test]
+fn syntax_error() {
+    eval_string("asdf fdsa asdf fdsa", |result| {
+        assert_eq!(result.unwrap_err().type_name(), "ErrorException");
+    });
+}
+
+#[test]
+fn define_then_use() {
+    eval_string("increase(x) = x + Int32(1)", |result| {
+        assert!(result.is_ok());
+    });
+    eval_string("increase(Int32(12))", |result| {
+        assert_eq!(result.unwrap().cast::<i32>().unwrap(), 13i32);
+    });
+    JULIA.with(|j| {
+        let mut jlrs = j.borrow_mut();
+        jlrs.frame(4, |global, frame| {
+            let func = Module::main(global).function("increase")?;
+            let twelve = Value::new(frame, 12i32).unwrap();
+            let result = func.call1(frame, twelve)?;
+            assert_eq!(result.unwrap().cast::<i32>().unwrap(), 13i32);
+            Ok(())
+        })
+        .unwrap();
+    });
+}


### PR DESCRIPTION
Added a function `eval_string` which serves as a safe wrapper around `jl_eval_string`. Added tests and documentation accordingly. A snippet from the documentation showing its semantics:
```rust
use jlrs::prelude::*;

julia.dynamic_frame(|global, frame| {
    let result = jlrs::eval_string(global, frame, "2 + 3")?.unwrap();
    assert_eq!(result.cast::<isize>().unwrap(), 5);

    jlrs::eval_string(global, frame, "increase(x) = x + 1")?.unwrap();
    let func = Module::main(global).function("increase")?;
    let twelve = Value::new(frame, 12isize).unwrap();
    let result = func.call1(frame, twelve)?;
    assert_eq!(result.unwrap().cast::<isize>().unwrap(), 13isize);

    Ok(())
})
.unwrap();
```
I would appreciate review on whether or not I used appropriate safety checks to eliminate undefined behavior.