### PR TITLE
Install JlrsCore if it's unavailable

### DIFF
--- a/jlrs_macros/Cargo.toml
+++ b/jlrs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jlrs-macros"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Thomas van Doornmalen <thomas.vandoornmalen@gmail.com>"]
 description = """
 jlrs-macros contains the custom derives offered by jlrs.

--- a/jlrs_macros/src/module.rs
+++ b/jlrs_macros/src/module.rs
@@ -626,7 +626,7 @@ impl JuliaModule {
                 let mut stack_frame = ::jlrs::memory::stack_frame::StackFrame::new();
                 let mut ccall = ::jlrs::ccall::CCall::new(&mut stack_frame);
 
-                ccall.init_jlrs(&::jlrs::InstallJlrsCore::No, Some(module));
+                ccall.init_jlrs(&::jlrs::InstallJlrsCore::Default, Some(module));
 
                 ccall.scope(|mut frame| {
                     let wrap_mod = ::jlrs::data::managed::module::Module::main(&frame)


### PR DESCRIPTION
Nightly CI fails due to a dependency of async-std failing to compile. See: https://github.com/async-rs/async-std/issues/1058