### PR TITLE
Use `Base.loaded_modules` instead of checking Main when loading JlrsCore

### DIFF
--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -864,13 +864,15 @@ impl InstallJlrsCore {
             InstallJlrsCore::Default => {
                 Value::eval_string(
                     unrooted,
-                    "if !isdefined(Main, :JlrsCore)
+                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
                          try
                              using JlrsCore
                          catch e
                              import Pkg; Pkg.add(\"JlrsCore\")
                              using JlrsCore
                          end
+                     else
+                         JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
                      end",
                 )
             },
@@ -878,13 +880,15 @@ impl InstallJlrsCore {
                 Value::eval_string(
                     unrooted,
                     format!(
-                        "if !isdefined(Main, :JlrsCore)
+                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
                              try
                                  using JlrsCore
                              catch e
                                  import Pkg; Pkg.add(url=\"{repo}#{revision}\")
                                  using JlrsCore
                              end
+                         else
+                             JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
                          end"
                     ),
                 )
@@ -893,13 +897,15 @@ impl InstallJlrsCore {
                 Value::eval_string(
                     unrooted,
                     format!(
-                        "if !isdefined(Main, :JlrsCore)
+                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
                              try
                                  using JlrsCore
                              catch e
                                  import Pkg; Pkg.add(name=\"JlrsCore\", version=\"{major}.{minor}.{patch}\")
                                  using JlrsCore
                              end
+                         else
+                             JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
                          end"
                     ),
                 )
@@ -907,8 +913,10 @@ impl InstallJlrsCore {
             InstallJlrsCore::No => {
                 Value::eval_string(
                     unrooted,
-                    "if !isdefined(Main, :JlrsCore)
+                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
                          using JlrsCore
+                     else
+                         JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
                      end",
                 )
             },

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -864,7 +864,7 @@ impl InstallJlrsCore {
             InstallJlrsCore::Default => {
                 Value::eval_string(
                     unrooted,
-                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
+                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\"))
                          try
                              using JlrsCore
                          catch e
@@ -872,7 +872,7 @@ impl InstallJlrsCore {
                              using JlrsCore
                          end
                      else
-                         JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
+                         const JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\")]
                      end",
                 )
             },
@@ -880,7 +880,7 @@ impl InstallJlrsCore {
                 Value::eval_string(
                     unrooted,
                     format!(
-                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
+                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\"))
                              try
                                  using JlrsCore
                              catch e
@@ -888,7 +888,7 @@ impl InstallJlrsCore {
                                  using JlrsCore
                              end
                          else
-                             JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
+                             const JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\")]
                          end"
                     ),
                 )
@@ -897,7 +897,7 @@ impl InstallJlrsCore {
                 Value::eval_string(
                     unrooted,
                     format!(
-                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
+                        "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\"))
                              try
                                  using JlrsCore
                              catch e
@@ -905,7 +905,7 @@ impl InstallJlrsCore {
                                  using JlrsCore
                              end
                          else
-                             JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
+                             const JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\")]
                          end"
                     ),
                 )
@@ -913,10 +913,10 @@ impl InstallJlrsCore {
             InstallJlrsCore::No => {
                 Value::eval_string(
                     unrooted,
-                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore"))
+                    "if !haskey(Base.loaded_modules, Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\"))
                          using JlrsCore
                      else
-                         JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID("29be08bc-e5fd-4da2-bbc1-72011c6ea2c9"), "JlrsCore")]
+                         const JlrsCore = Base.loaded_modules[Base.PkgId(Base.UUID(\"29be08bc-e5fd-4da2-bbc1-72011c6ea2c9\"), \"JlrsCore\")]
                      end",
                 )
             },


### PR DESCRIPTION
This commit allows JlrsCore to be detected if it is loaded at any point in the given session, not just from `main`.  I'm not sure if this is the best approach, but it's probably better than hard-checking if `Main.JlrsCore` is a thing.