### PR TITLE
Reduce MSRV to 1.77, make diagnostics a feature.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,6 +195,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Install JlrsCore
+        run: julia --color=yes -e 'using Pkg; Pkg.add("JlrsCore"); VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+        shell: bash
+        env:
+          JULIA_PKG_SERVER: ""
+
       - name: Run tests
         run: |
           cargo test --features full,julia-1-6 --verbose
@@ -221,6 +227,12 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+
+      - name: Install JlrsCore
+        run: julia --color=yes -e 'using Pkg; Pkg.add("JlrsCore"); VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+        shell: bash
+        env:
+          JULIA_PKG_SERVER: ""
 
       - name: Run tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### v0.20
 
-- Add support for Julia 1.11. Bump MSRV to 1.78.
+- Add support for Julia 1.11. Bump MSRV to 1.77.
 
 - The layout of builtin types defined by the C API like `jl_datatype_t` and `jl_module_t` are opaque to jlrs. Any access to their internals is delegated to functions defined in jl-sys's support library.
 
@@ -50,7 +50,7 @@
 
 - Scopes can return arbitrary types, the return type is no longer required to be a `JlrsResult`.
 
-- Custom diagnostics are emitted when `ValidLayout`, `Unbox`, `IntoJulia`, `ConstructType`, `Typecheck` or `ForeignType` has not been implemented to explicitly warn you probably don't want `ForeignType`'s blanket impementations for these traits.
+- Custom diagnostics are emitted when `ValidLayout`, `Unbox`, `IntoJulia`, `ConstructType`, `Typecheck` or `ForeignType` has not been implemented to explicitly warn you probably don't want `ForeignType`'s blanket impementations for these traits. This requires enabling the `diagnostics` feature and Rust 1.78.
 
 - Initializing Julia is considered safe as long as no custom system image is used.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ applications and to write interop libraries to Rust crates that can be used by J
 
 Julia versions 1.6 up to and including 1.11 are supported, but only the LTS and stable versions
 are actively tested. Using the current stable version of Julia is highly recommended. The minimum
-supported Rust version is currently 1.78.
+supported Rust version is currently 1.77.
 
 This readme only contains information about what features are supported by jlrs, what
 prerequisites must be met, and how to meet them. For information and examples about how to use
@@ -198,6 +198,11 @@ All other features are called utility features. The following are available:
   `RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang-XX -Clink-arg=-fuse-ld=lld -Clink-args=-rdynamic"`.
   The last one is particularly important for embedders, forgetting it is guaranteed to kill
   performance.
+
+- `diagnostics`
+
+  Enable custom diagnostics for several traits because the default lint is unhelpful. This feature
+  requires Rust 1.78.
 
 - `i686`
 

--- a/jlrs/Cargo.toml
+++ b/jlrs/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["Julia", "math", "mathematics", "bindings", "ffi"]
 categories = ["api-bindings", "mathematics"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.77"
 
 [features]
 default = []
@@ -74,6 +74,8 @@ jlrs-ndarray = ["ndarray"]
 jlrs-derive = ["jlrs-macros/derive"]
 # Compile the support library with support for cross-language LTO.
 lto = ["jl-sys/lto"]
+
+diagnostics = []
 
 # Target or link a specific Julia build or arch.
 

--- a/jlrs/src/convert/into_julia.rs
+++ b/jlrs/src/convert/into_julia.rs
@@ -45,12 +45,12 @@ use crate::{
 /// behavior. The type in Rust must always be `#[repr(C)]`. The `DataType` must be an isbits-type.
 ///
 /// [`Value::new`]: crate::data::managed::value::Value::new
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: IntoJulia` is not satisfied",
     label = "the trait `IntoJulia` is not implemented for `{Self}`",
     note = "Custom types that implement `IntoJulia` should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 pub unsafe trait IntoJulia: Sized + 'static {
     /// Returns the associated Julia type of the implementor.
     ///

--- a/jlrs/src/convert/unbox.rs
+++ b/jlrs/src/convert/unbox.rs
@@ -48,12 +48,12 @@ use crate::data::managed::value::Value;
 ///
 /// [`Value::unbox`]: crate::data::managed::value::Value::unbox
 /// [`ValidLayout`]: crate::data::layout::valid_layout::ValidLayout
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: Unbox` is not satisfied",
     label = "the trait `Unbox` is not implemented for `{Self}`",
     note = "Custom types that implement `Unbox` should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 pub unsafe trait Unbox {
     /// The type of the unboxed data. Must be `#[repr(C)]`.
     type Output: Sized + Clone;

--- a/jlrs/src/data/layout/valid_layout.rs
+++ b/jlrs/src/data/layout/valid_layout.rs
@@ -30,12 +30,12 @@ use crate::{
 /// Safety: implementations of [`ValidLayout::valid_layout`] must not trigger the GC. This means
 /// no function can be called that allocates Julia data, calls Julia functions, or can trigger the
 /// GC some other way.
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: ValidLayout` is not satisfied",
     label = "the trait `ValidLayout` is not implemented for `{Self}`",
     note = "Custom types that implement `ValidLayout` should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 pub unsafe trait ValidLayout {
     /// Must be `true` if the Rust type is a managed type.
     const IS_REF: bool = false;

--- a/jlrs/src/data/types/construct_type.rs
+++ b/jlrs/src/data/types/construct_type.rs
@@ -211,12 +211,12 @@ macro_rules! bytes {
 ///
 /// `ConstructType::construct_type` must either return a valid type object, or an instance of an
 /// isbits type which is immediately used as a type parameter of another constructed type.
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: ConstructType` is not satisfied",
     label = "the trait `ConstructType` is not implemented for `{Self}`",
     note = "Custom types that implement `ConstructType` should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 
 pub unsafe trait ConstructType: Sized {
     /// `Self`, but with all lifetimes set to `'static`. This ensures `Self::Static` has a type

--- a/jlrs/src/data/types/foreign_type.rs
+++ b/jlrs/src/data/types/foreign_type.rs
@@ -689,7 +689,7 @@ pub unsafe trait ParametricVariant: ParametricBase {
 /// [`Ref::leak`]: crate::data::managed::Ref::leak
 /// [`write_barrier`]: crate::memory::gc::write_barrier
 
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: ForeignLayout` is not satisfied",
     label = "the trait `ForeignLayout` is not implemented for `{Self}`",
     note = "Unless you are calling a function that explicitly takes an implementation of \
@@ -697,7 +697,7 @@ pub unsafe trait ParametricVariant: ParametricBase {
     note = "It is more likely that the issue lies with not implementing `ValidLayout`, `IntoJulia`, `Typecheck`, `Unbox` or `ConstructType`",
     note = "Custom types that implement the traits mentioned in the previous note should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 pub unsafe trait ForeignType: Sized + Send + 'static {
     #[doc(hidden)]
     const TYPE_FN: Option<unsafe fn() -> DataType<'static>> = None;

--- a/jlrs/src/data/types/typecheck.rs
+++ b/jlrs/src/data/types/typecheck.rs
@@ -32,12 +32,12 @@ use crate::{
 /// [`Value::is`]: crate::data::managed::value::Value::is
 /// [`Unbox`]: crate::convert::unbox::Unbox
 /// [`Managed`]: crate::data::managed::Managed
-#[diagnostic::on_unimplemented(
+#[cfg_attr(feature = "diagnostics", diagnostic::on_unimplemented(
     message = "the trait bound `{Self}: Typecheck` is not satisfied",
     label = "the trait `Typecheck` is not implemented for `{Self}`",
     note = "Custom types that implement `Typecheck` should be generated with JlrsCore.reflect",
     note = "Do not implement `ForeignType`, `OpaqueType`, or `ParametricVariant` unless this type is exported to Julia with `julia_module!`"
-)]
+))]
 pub unsafe trait Typecheck {
     /// Returns whether the property implied by `Self` holds true.
     fn typecheck(t: DataType) -> bool;

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! Julia versions 1.6 up to and including 1.11 are supported, but only the LTS and stable versions
 //! are actively tested. Using the current stable version of Julia is highly recommended. The
-//! minimum supported Rust version is currently 1.78.
+//! minimum supported Rust version is currently 1.77.
 //!
 //!
 //! # Overview
@@ -192,6 +192,11 @@
 //!   `CC` environment variable. Setting `RUSTFLAGS` overrides the default flags that jlrs sets, so
 //!   you must set at least the following flags:
 //!   `RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang-XX -Clink-arg=-fuse-ld=lld -Clink-args=-rdynamic"`.
+//!
+//! - `diagnostics`
+//!
+//!   Enable custom diagnostics for several traits because the default lint is unhelpful. This feature
+//!   requires Rust 1.78.
 //!
 //! - `i686`
 //!

--- a/jlrs_macros/Cargo.toml
+++ b/jlrs_macros/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 keywords = ["Julia", "math", "mathematics", "bindings", "ffi"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.77"
 
 [features]
 default = []


### PR DESCRIPTION
BinaryBuilder currently uses 1.77, diagnostics are the only feature that's particularly useful to jlrs stabilized in 1.78.