### PR TITLE
Load missing functions at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Unused internal types have been removed, `Expr` is no longer considered an internal type.
 
-- Static symbols can be defined with the `define_static_symbol` macro. 
+- Static symbols can be defined with the `define_static_symbol` macro.
 
 - Arrays have been redesigned to be more consistent with the rest of jlrs: there is a single fundamental array type, `ArrayBase`, and a bunch of aliases that expose additional static type information if desired. The first type parameter of a `TypedArray` is the type constructor of the element type, not the element type's layout. Many functions now return a `TypedArray` instead of an `Array`.
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ A runtime lets initialize Julia from Rust application, the following features en
   threads. It can be combined with the `async-rt` feature to create Julia-aware thread pools. This
   feature requires Julia 1.9 or higher.
 
-**WARNING**: Runtime features must only be enabled by applications that embed Julia. Libraries 
+**WARNING**: Runtime features must only be enabled by applications that embed Julia. Libraries
 must never enable a runtime feature.
 
-**WARNING**: When a runtime feature is enabled on Linux, set `RUSTFLAGS="-Clink-args=-rdynamic"` 
+**WARNING**: When a runtime feature is enabled on Linux, set `RUSTFLAGS="-Clink-args=-rdynamic"`
 if you want fast code.
 
 ### Utilities

--- a/benches/benches/arrays.rs
+++ b/benches/benches/arrays.rs
@@ -59,10 +59,7 @@ fn construct_array_2d_unchecked_unrooted(frame: &mut GcFrame, c: &mut Criterion)
 }
 
 #[inline(never)]
-fn construct_array_2d_unchecked_unrooted2(
-    frame: &mut GcFrame,
-    c: &mut Criterion,
-) {
+fn construct_array_2d_unchecked_unrooted2(frame: &mut GcFrame, c: &mut Criterion) {
     jlrs::define_fast_array_key!(pub Foo, f32, 2);
 
     c.bench_function("Array<f64,2>_unchecked_unrooted2", |b| {
@@ -92,10 +89,7 @@ fn construct_array_3d_arrdim_unrooted(frame: &mut GcFrame, c: &mut Criterion) {
 }
 
 #[inline(never)]
-fn construct_array_3d_arrdim_unchecked_unrooted(
-    frame: &mut GcFrame,
-    c: &mut Criterion,
-) {
+fn construct_array_3d_arrdim_unchecked_unrooted(frame: &mut GcFrame, c: &mut Criterion) {
     c.bench_function("Array<f64,3>_arrdim_unchecked_unrooted", |b| {
         b.iter(|| unsafe { TypedArray::<f64>::new_unchecked(&frame, [4, 2, 2]) })
     });
@@ -116,10 +110,7 @@ fn construct_array_4d_unchecked_unrooted(frame: &mut GcFrame, c: &mut Criterion)
 }
 
 #[inline(never)]
-fn construct_array_1d_from_slice_unrooted(
-    frame: &mut GcFrame,
-    c: &mut Criterion,
-) {
+fn construct_array_1d_from_slice_unrooted(frame: &mut GcFrame, c: &mut Criterion) {
     let mut v = [1.0; 16];
     let mut v = NonNull::from(&mut v);
     c.bench_function("Array<f64,1>_from_slice_unrooted", |b| {
@@ -131,10 +122,7 @@ fn construct_array_1d_from_slice_unrooted(
 }
 
 #[inline(never)]
-fn construct_array_1d_from_slice_unchecked_unrooted(
-    frame: &mut GcFrame,
-    c: &mut Criterion,
-) {
+fn construct_array_1d_from_slice_unchecked_unrooted(frame: &mut GcFrame, c: &mut Criterion) {
     let mut v = [1.0; 16];
     let mut v = NonNull::from(&mut v);
     c.bench_function("Array<f64,1>_from_slice_unchecked_unrooted", |b| {
@@ -156,10 +144,7 @@ fn construct_array_1d_from_vec_unrooted(frame: &mut GcFrame, c: &mut Criterion) 
 }
 
 #[inline(never)]
-fn construct_array_1d_from_vec_unchecked_unrooted(
-    frame: &mut GcFrame,
-    c: &mut Criterion,
-) {
+fn construct_array_1d_from_vec_unchecked_unrooted(frame: &mut GcFrame, c: &mut Criterion) {
     c.bench_function("Array<f64,1>_from_vec_unchecked_unrooted", |b| {
         b.iter(|| {
             let v: Vec<f64> = Vec::new();

--- a/benches/benches/call_function.rs
+++ b/benches/benches/call_function.rs
@@ -115,47 +115,47 @@ fn bench_group(c: &mut Criterion) {
 
     julia.with_stack(|mut stack| {
         stack.scope(|mut frame| {
-            let func =unsafe{ 
+            let func =unsafe{
                 Value::eval_string(&frame, "function dummy(a1::Any=nothing, a2::Any=nothing, a3::Any=nothing, a4::Any=nothing, a5::Any=nothing, a6::Any=nothing)
                     @nospecialize a1 a2 a3 a4 a5 a6
                 end").unwrap().as_value()
             };
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_0_unchecked(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_0(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_1_unchecked(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_1(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_2_unchecked(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_2(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             call_3_unchecked(&mut frame, c, func).unwrap();
-            
+
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
             frame.gc_collect(jlrs::memory::gc::GcCollection::Full);

--- a/benches/benches/frames.rs
+++ b/benches/benches/frames.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use jlrs::{
-    prelude::*, runtime::handle::local_handle::LocalHandle,
-    weak_handle, weak_handle_unchecked,
+    prelude::*, runtime::handle::local_handle::LocalHandle, weak_handle, weak_handle_unchecked,
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::{

--- a/benches/benches/mt_rt_pool.rs
+++ b/benches/benches/mt_rt_pool.rs
@@ -3,8 +3,7 @@ use std::{cell::RefCell, future::Future};
 use criterion::{
     async_executor::AsyncExecutor, black_box, criterion_group, criterion_main, Criterion,
 };
-use jlrs::prelude::*;
-use jlrs::runtime::handle::mt_handle::MtHandle;
+use jlrs::{prelude::*, runtime::handle::mt_handle::MtHandle};
 #[cfg(not(target_os = "windows"))]
 use pprof::{
     criterion::{Output, PProfProfiler},
@@ -23,9 +22,7 @@ impl AsyncExecutor for TokioExecutor {
         RUNTIME.with(|rt_refcell| {
             let mut rt_ref = rt_refcell.borrow_mut();
             if rt_ref.is_none() {
-                *rt_ref = tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .ok();
+                *rt_ref = tokio::runtime::Builder::new_current_thread().build().ok();
             }
 
             let rt = rt_ref.as_ref().unwrap();

--- a/jl_sys/src/bindings.rs
+++ b/jl_sys/src/bindings.rs
@@ -1309,10 +1309,10 @@ extern "C" {
     pub fn jlrs_typename_mayinlinealloc(tn: *mut crate::types::jl_typename_t) -> u8;
 
     #[cfg(not(feature = "julia-1-6"))]
-    pub fn jlrs_lock_nogc(v: *mut crate::types::jl_value_t);
+    pub fn jlrs_lock_value(v: *mut crate::types::jl_value_t);
 
     #[cfg(not(feature = "julia-1-6"))]
-    pub fn jlrs_unlock_nogc(v: *mut crate::types::jl_value_t);
+    pub fn jlrs_unlock_value(v: *mut crate::types::jl_value_t);
 
     // Added in Julia 1.8
 

--- a/jl_sys/src/bindings.rs
+++ b/jl_sys/src/bindings.rs
@@ -1272,8 +1272,6 @@ extern "C" {
 
     pub fn jlrs_array_typetagdata(a: *mut crate::types::jl_array_t) -> *mut std::ffi::c_char;
 
-    pub fn jlrs_array_dims_ptr(a: *mut crate::types::jl_array_t) -> *mut usize;
-
     pub fn jlrs_array_is_pointer_array(a: *mut crate::types::jl_array_t) -> std::ffi::c_int;
 
     pub fn jlrs_array_is_union_array(a: *mut crate::types::jl_array_t) -> std::ffi::c_int;

--- a/jl_sys/src/bindings.rs
+++ b/jl_sys/src/bindings.rs
@@ -963,6 +963,7 @@ extern "C" {
     //     nb: std::ffi::c_int,
     // ) -> *mut crate::types::jl_value_t;
 
+    // // Used indirectly
     // #[cfg(not(feature = "julia-1-6"))]
     // pub fn jl_atomic_bool_cmpswap_bits(
     //     dst: *mut std::ffi::c_char,
@@ -971,6 +972,7 @@ extern "C" {
     //     nb: std::ffi::c_int,
     // ) -> std::ffi::c_int;
 
+    // // Used indirectly
     // #[cfg(not(feature = "julia-1-6"))]
     // pub fn jl_atomic_cmpswap_bits(
     //     dt: *mut crate::types::jl_datatype_t,
@@ -1309,12 +1311,6 @@ extern "C" {
     pub fn jlrs_typename_mayinlinealloc(tn: *mut crate::types::jl_typename_t) -> u8;
 
     #[cfg(not(feature = "julia-1-6"))]
-    pub fn jlrs_lock(v: *mut crate::types::jl_value_t);
-
-    #[cfg(not(feature = "julia-1-6"))]
-    pub fn jlrs_unlock(v: *mut crate::types::jl_value_t);
-
-    #[cfg(not(feature = "julia-1-6"))]
     pub fn jlrs_lock_nogc(v: *mut crate::types::jl_value_t);
 
     #[cfg(not(feature = "julia-1-6"))]
@@ -1345,4 +1341,6 @@ extern "C" {
     pub fn jlrs_genericmemory_typetagdata(
         m: *mut crate::types::jl_genericmemory_t,
     ) -> *mut std::ffi::c_char;
+
+    pub fn jlrs_init_missing_functions();
 }

--- a/jl_sys/src/inlined.rs
+++ b/jl_sys/src/inlined.rs
@@ -1,0 +1,154 @@
+// If LTO is not enabled accessing arrays is very slow, so we're going to optimize
+// the common case a little.
+
+use std::ptr::NonNull;
+
+use crate::jl_array_t;
+
+#[cfg(any(
+    feature = "julia-1-6",
+    feature = "julia-1-7",
+    feature = "julia-1-8",
+    feature = "julia-1-9",
+    feature = "julia-1-10"
+))]
+#[inline]
+pub const unsafe fn jlrs_array_data_fast(a: *mut jl_array_t) -> *mut std::ffi::c_void {
+    #[repr(C)]
+    struct RawArray {
+        ptr: *mut std::ffi::c_void,
+    }
+
+    NonNull::new_unchecked(a as *mut RawArray).as_ref().ptr
+}
+
+#[cfg(not(any(
+    feature = "julia-1-6",
+    feature = "julia-1-7",
+    feature = "julia-1-8",
+    feature = "julia-1-9",
+    feature = "julia-1-10"
+)))]
+#[inline]
+pub const unsafe fn jlrs_array_data_fast(a: *mut jl_array_t) -> *mut std::ffi::c_void {
+    #[repr(C)]
+    struct GenericMemoryRef {
+        ptr_or_offset: *mut std::ffi::c_void,
+        mem: *mut std::ffi::c_void,
+    }
+
+    #[repr(C)]
+    struct RawArray {
+        ref_inner: GenericMemoryRef,
+    }
+
+    NonNull::new_unchecked(a as *mut RawArray)
+        .as_ref()
+        .ref_inner
+        .ptr_or_offset
+}
+
+#[cfg(any(
+    feature = "julia-1-6",
+    feature = "julia-1-7",
+    feature = "julia-1-8",
+    feature = "julia-1-9",
+    feature = "julia-1-10"
+))]
+#[inline]
+pub const unsafe fn jlrs_array_dims_ptr(a: *mut jl_array_t) -> *mut usize {
+    #[repr(C)]
+    struct RawArray {
+        data: *mut std::ffi::c_void,
+        length: usize,
+        flags: u16,
+        elsize: u16,
+        offset: u32,
+        nrows: usize,
+    }
+
+    const OFFSET: usize = std::mem::offset_of!(RawArray, nrows);
+    (a as *mut u8).add(OFFSET) as *mut usize
+}
+
+#[cfg(not(any(
+    feature = "julia-1-6",
+    feature = "julia-1-7",
+    feature = "julia-1-8",
+    feature = "julia-1-9",
+    feature = "julia-1-10"
+)))]
+#[inline]
+pub const unsafe fn jlrs_array_dims_ptr(a: *mut jl_array_t) -> *mut usize {
+    #[repr(C)]
+    struct GenericMemoryRef {
+        ptr_or_offset: *mut std::ffi::c_void,
+        mem: *mut std::ffi::c_void,
+    }
+
+    #[repr(C)]
+    struct RawArray {
+        ref_inner: GenericMemoryRef,
+    }
+
+    const OFFSET: usize = std::mem::size_of::<RawArray>();
+    (a as *mut u8).add(OFFSET) as *mut usize
+}
+
+#[cfg(not(any(
+    feature = "julia-1-6",
+    feature = "julia-1-7",
+    feature = "julia-1-8",
+    feature = "julia-1-9",
+    feature = "julia-1-10"
+)))]
+#[inline]
+pub const unsafe fn jlrs_array_mem(a: *mut jl_array_t) -> *mut crate::types::jl_value_t {
+    #[repr(C)]
+    struct GenericMemoryRef {
+        ptr_or_offset: *mut std::ffi::c_void,
+        mem: *mut std::ffi::c_void,
+    }
+
+    #[repr(C)]
+    struct RawArray {
+        ref_inner: GenericMemoryRef,
+    }
+
+    NonNull::new_unchecked(a as *mut RawArray)
+        .as_ref()
+        .ref_inner
+        .mem as _
+}
+
+#[inline]
+pub const unsafe fn jlrs_array_ndims_fast(a: *mut jl_array_t) -> usize {
+    #[repr(C)]
+    struct RawDataType {
+        name: *mut std::ffi::c_void,
+        super_ty: *mut std::ffi::c_void,
+        parameters: *mut std::ffi::c_void,
+    }
+
+    #[repr(C)]
+    union Header {
+        header: usize,
+        next: *mut TaggedValue,
+        ty: *mut RawDataType,
+        bits: usize,
+    }
+
+    #[repr(C)]
+    struct TaggedValue {
+        header: Header,
+    }
+
+    let a = a as *mut u8;
+    let tagged = a
+        .sub(std::mem::size_of::<TaggedValue>())
+        .cast::<TaggedValue>();
+    let header = NonNull::new_unchecked(tagged).as_ref().header.header;
+    let dt = (header & !15) as *mut RawDataType;
+    let params = NonNull::new_unchecked(dt).as_ref().parameters as *mut *mut usize;
+    params.add(2).read().read()
+}

--- a/jl_sys/src/jlrs_cc/jlrs_cc_ext.c
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_ext.c
@@ -375,15 +375,6 @@ extern "C"
 #endif
     }
 
-    size_t *jlrs_array_dims_ptr(jl_array_t *a)
-    {
-#if JULIA_VERSION_MINOR >= 11
-        return a->dimsize;
-#else
-    return &a->nrows;
-#endif
-    }
-
     int jlrs_array_is_pointer_array(jl_array_t *a)
     {
 #if JULIA_VERSION_MINOR >= 11

--- a/jl_sys/src/jlrs_cc/jlrs_cc_ext.h
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_ext.h
@@ -110,8 +110,7 @@ extern "C" {
     void jlrs_arrayset(jl_array_t *a, jl_value_t *v, size_t i);
     jl_value_t *jlrs_array_data_owner(jl_array_t *a);
     char *jlrs_array_typetagdata(jl_array_t *a);
-    
-    size_t *jlrs_array_dims_ptr(jl_array_t *a);
+
     int jlrs_array_is_pointer_array(jl_array_t *a);
     int jlrs_array_is_union_array(jl_array_t *a);
     int jlrs_array_has_pointers(jl_array_t *a);

--- a/jl_sys/src/jlrs_cc/jlrs_cc_hacks.c
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_hacks.c
@@ -48,14 +48,14 @@ extern "C"
     }
 
 #if JULIA_VERSION_MINOR >= 7
-    void jlrs_lock_nogc(jl_value_t *v)
+    void jlrs_lock_value(jl_value_t *v)
     {
 
         assert(jl_lock_value_func && "jl_lock_value_func not loaded");
         jl_lock_value_func(v);
     }
 
-    void jlrs_unlock_nogc(jl_value_t *v)
+    void jlrs_unlock_value(jl_value_t *v)
     {
         assert(jl_unlock_value_func && "jl_unlock_value_func not loaded");
         jl_unlock_value_func(v);

--- a/jl_sys/src/jlrs_cc/jlrs_cc_hacks.c
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_hacks.c
@@ -4,315 +4,82 @@
 extern "C"
 {
 #endif
-    int8_t jlrs_gc_safe_enter(jl_ptls_t ptls)
-    {
-        return jl_gc_safe_enter(ptls);
-    }
 
-    int8_t jlrs_gc_unsafe_enter(jl_ptls_t ptls)
-    {
-        return jl_gc_unsafe_enter(ptls);
-    }
+#if JULIA_VERSION_MINOR >= 7
+    typedef void (*jl_lock_value_func_t)(void *);
 
-    void jlrs_gc_safe_leave(jl_ptls_t ptls, int8_t state)
-    {
-        jl_gc_safe_leave(ptls, state);
-    }
+    static jl_lock_value_func_t jl_lock_value_func;
+    static jl_lock_value_func_t jl_unlock_value_func;
 
-    void jlrs_gc_unsafe_leave(jl_ptls_t ptls, int8_t state)
+#if JULIA_VERSION_MINOR >= 11
+    typedef jl_genericmemoryref_t (*jl_memoryrefindex_func_t)(jl_genericmemoryref_t, size_t);
+    typedef void (*jl_memoryrefset_func_t)(jl_genericmemoryref_t, jl_value_t *, int);
+    typedef char *(*jl_genericmemory_typetagdata_func_t)(jl_genericmemory_t *);
+
+    static jl_memoryrefindex_func_t jl_memoryrefindex_func;
+    static jl_memoryrefset_func_t jl_memoryrefset_func;
+    static jl_genericmemory_typetagdata_func_t jl_genericmemory_typetagdata_func;
+#endif
+#endif
+
+    void jlrs_init_missing_functions(void)
     {
-        jl_gc_unsafe_leave(ptls, state);
+#if JULIA_VERSION_MINOR >= 7
+        void ***libjulia_internal_handle_ref_v = (void ***)jl_eval_string("cglobal(:jl_libjulia_internal_handle)");
+        void *libjulia_internal_handle = **libjulia_internal_handle_ref_v;
+
+        int found_jl_lock_value = jl_dlsym(libjulia_internal_handle, "jl_lock_value", (void **)&jl_lock_value_func, 0);
+        assert(found_jl_lock_value);
+
+        int found_jl_unlock_value = jl_dlsym(libjulia_internal_handle, "jl_unlock_value", (void **)&jl_unlock_value_func, 0);
+        assert(found_jl_unlock_value);
+
+#if JULIA_VERSION_MINOR >= 11
+        int found_jl_memoryrefindex = jl_dlsym(libjulia_internal_handle, "jl_memoryrefindex", (void **)&jl_memoryrefindex_func, 0);
+        assert(found_jl_memoryrefindex);
+
+        int found_jl_memoryrefset = jl_dlsym(libjulia_internal_handle, "jl_memoryrefset", (void **)&jl_memoryrefset_func, 0);
+        assert(found_jl_memoryrefset);
+
+        int found_jl_genericmemory_typetagdata = jl_dlsym(libjulia_internal_handle, "jl_genericmemory_typetagdata", (void **)&jl_genericmemory_typetagdata_func, 0);
+        assert(found_jl_genericmemory_typetagdata);
+#endif
+#endif
     }
 
 #if JULIA_VERSION_MINOR >= 7
-    void jlrs_small_arraylist_grow(small_arraylist_t *a, uint32_t n)
-    {
-        size_t len = a->len;
-        size_t newlen = len + n;
-        if (newlen > a->max)
-        {
-            if (a->items == &a->_space[0])
-            {
-                void **p = (void **)LLT_ALLOC((a->len + n) * sizeof(void *));
-                if (p == NULL)
-                    return;
-                memcpy(p, a->items, len * sizeof(void *));
-                a->items = p;
-                a->max = newlen;
-            }
-            else
-            {
-                size_t nm = a->max * 2;
-                if (nm == 0)
-                    nm = 1;
-                while (newlen > nm)
-                    nm *= 2;
-                void **p = (void **)LLT_REALLOC(a->items, nm * sizeof(void *));
-                if (p == NULL)
-                    return;
-                a->items = p;
-                a->max = nm;
-            }
-        }
-        a->len = newlen;
-    }
-
-    static void jlrs_lock_frame_push(jl_task_t *self, jl_mutex_t *lock)
-    {
-        jl_ptls_t ptls = self->ptls;
-        small_arraylist_t *locks = &ptls->locks;
-        uint32_t len = locks->len;
-        if (__unlikely(len >= locks->max))
-        {
-            jlrs_small_arraylist_grow(locks, 1);
-        }
-        else
-        {
-            locks->len = len + 1;
-        }
-        locks->items[len] = (void *)lock;
-    }
-
-    static void jlrs_lock_frame_pop(jl_task_t *self)
-    {
-        jl_ptls_t ptls = self->ptls;
-        assert(ptls->locks.len > 0);
-        ptls->locks.len--;
-    }
-
-    static void jlrs_mutex_wait(jl_task_t *self, jl_mutex_t *lock, int safepoint)
-    {
-        jl_task_t *owner = jl_atomic_load_relaxed(&lock->owner);
-        if (owner == self)
-        {
-            lock->count++;
-            return;
-        }
-
-        if (owner == NULL && jl_atomic_cmpswap(&lock->owner, &owner, self))
-        {
-            lock->count = 1;
-            return;
-        }
-
-        while (1)
-        {
-            if (owner == NULL && jl_atomic_cmpswap(&lock->owner, &owner, self))
-            {
-                lock->count = 1;
-                return;
-            }
-            if (safepoint)
-            {
-                jl_gc_safepoint_(self->ptls);
-            }
-
-#if JULIA_VERSION_MINOR <= 9
-            jl_cpu_pause();
-#else
-            jl_cpu_suspend();
-#endif
-            owner = jl_atomic_load_relaxed(&lock->owner);
-        }
-    }
-
-    static void jlrs_mutex_unlock_nogc(jl_mutex_t *lock)
-    {
-        assert(jl_atomic_load_relaxed(&lock->owner) == jl_current_task &&
-               "Unlocking a lock in a different thread.");
-
-        if (--lock->count == 0)
-        {
-            jl_atomic_store_release(&lock->owner, (jl_task_t *)NULL);
-            jl_cpu_wake();
-        }
-    }
-
-    void jlrs_lock(jl_value_t *v)
-    {
-        jl_task_t *self = jl_current_task;
-        jl_mutex_t *lock = (jl_mutex_t *)v;
-
-#if JULIA_VERSION_MINOR <= 8
-        JL_SIGATOMIC_BEGIN();
-#else
-        JL_SIGATOMIC_BEGIN_self();
-#endif
-
-        jlrs_mutex_wait(self, lock, 1);
-        jlrs_lock_frame_push(self, lock);
-    }
-
     void jlrs_lock_nogc(jl_value_t *v)
     {
-        jl_task_t *self = jl_current_task;
-        jl_mutex_t *lock = (jl_mutex_t *)v;
-        jlrs_mutex_wait(self, lock, 0);
-    }
 
-    void jlrs_unlock(jl_value_t *v)
-    {
-        jl_task_t *self = jl_current_task;
-        jl_mutex_t *lock = (jl_mutex_t *)v;
-
-        jlrs_mutex_unlock_nogc(lock);
-        jlrs_lock_frame_pop(self);
-
-#if JULIA_VERSION_MINOR <= 8
-        JL_SIGATOMIC_END();
-#else
-        JL_SIGATOMIC_END_self();
-#endif
-
-        // FIXME
-        // if (jl_atomic_load_relaxed(&jl_gc_have_pending_finalizers))
-        // {
-        //     jl_gc_run_pending_finalizers(self); // may GC
-        // }
+        assert(jl_lock_value_func && "jl_lock_value_func not loaded");
+        jl_lock_value_func(v);
     }
 
     void jlrs_unlock_nogc(jl_value_t *v)
     {
-        jl_mutex_t *lock = (jl_mutex_t *)v;
-        jlrs_mutex_unlock_nogc(lock);
+        assert(jl_unlock_value_func && "jl_unlock_value_func not loaded");
+        jl_unlock_value_func(v);
     }
-#endif
 
 #if JULIA_VERSION_MINOR >= 11
-
-#define JL_SMALL_BYTE_ALIGNMENT 16
-
-    int jlrs_memoryref_isassigned(jl_genericmemoryref_t m, int isatomic)
+    jl_genericmemoryref_t jlrs_memoryrefindex(jl_genericmemoryref_t m, size_t idx)
     {
-        const jl_datatype_layout_t *layout = ((jl_datatype_t *)jl_typetagof(m.mem))->layout;
-        _Atomic(jl_value_t *) *elem = (_Atomic(jl_value_t *) *)m.ptr_or_offset;
-        if (layout->flags.arrayelem_isboxed)
-        {
-        }
-        else if (layout->first_ptr >= 0)
-        {
-            int needlock = isatomic && layout->size > MAX_ATOMIC_SIZE;
-            if (needlock)
-                elem = elem + LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT) / sizeof(jl_value_t *);
-            elem = &elem[layout->first_ptr];
-        }
-        else
-        {
-            return 1;
-        }
-        return (isatomic ? jl_atomic_load(elem) : jl_atomic_load_relaxed(elem)) != NULL;
+        assert(jl_memoryrefindex_func && "jl_memoryrefindex_func not loaded");
+        return jl_memoryrefindex_func(m, idx);
     }
 
-    int jlrs_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT
+    void jlrs_memoryrefset(jl_genericmemoryref_t m, jl_value_t *rhs, int isatomic)
     {
-        while (jl_is_uniontype(haystack))
-        {
-            jl_uniontype_t *u = (jl_uniontype_t *)haystack;
-            if (jlrs_find_union_component(u->a, needle, nth))
-                return 1;
-            haystack = u->b;
-        }
-        if (needle == haystack)
-            return 1;
-        (*nth)++;
-        return 0;
-    }
-
-    jl_genericmemoryref_t jlrs_memoryrefindex(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, size_t idx)
-    {
-        const jl_datatype_layout_t *layout = ((jl_datatype_t *)jl_typetagof(m.mem))->layout;
-        if ((layout->flags.arrayelem_isboxed || !layout->flags.arrayelem_isunion) && layout->size != 0)
-        {
-            m.ptr_or_offset = (void *)((char *)m.ptr_or_offset + idx * layout->size);
-            assert((size_t)((char *)m.ptr_or_offset - (char *)m.mem->ptr) < (size_t)(layout->size * m.mem->length));
-        }
-        else
-        {
-            m.ptr_or_offset = (void *)((size_t)m.ptr_or_offset + idx);
-            assert((size_t)m.ptr_or_offset < m.mem->length);
-        }
-        return m;
-    }
-
-    void jlrs_memoryrefset(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, int isatomic)
-    {
-        // Caller must guarantee this, jl_atomic_sym is not exported by the C API.
-        // assert(isatomic == (jl_tparam0(jl_typetagof(m.mem)) == (jl_value_t*)jl_atomic_sym));
-        jl_value_t *eltype = jl_tparam1(jl_typetagof(m.mem));
-        if (eltype != (jl_value_t *)jl_any_type && !jl_typeis(rhs, eltype))
-        {
-            JL_GC_PUSH1(&rhs);
-            if (!jl_isa(rhs, eltype))
-                jl_type_error("memoryrefset!", eltype, rhs);
-            JL_GC_POP();
-        }
-        const jl_datatype_layout_t *layout = ((jl_datatype_t *)jl_typetagof(m.mem))->layout;
-        if (layout->flags.arrayelem_isboxed)
-        {
-            assert((size_t)((char *)m.ptr_or_offset - (char *)m.mem->ptr) < (size_t)(sizeof(jl_value_t *) * m.mem->length));
-            if (isatomic)
-                jl_atomic_store((_Atomic(jl_value_t *) *)m.ptr_or_offset, rhs);
-            else
-                jl_atomic_store_release((_Atomic(jl_value_t *) *)m.ptr_or_offset, rhs);
-            jl_gc_wb(jl_genericmemory_owner(m.mem), rhs);
-            return;
-        }
-        int hasptr;
-        char *data = (char *)m.ptr_or_offset;
-        if (layout->flags.arrayelem_isunion)
-        {
-            assert(!isatomic);
-            assert(jl_is_uniontype(eltype));
-            size_t i = (size_t)data;
-            assert(i < m.mem->length);
-            // uint8_t *psel = (uint8_t*)jl_genericmemory_typetagdata(m.mem) + i;
-            uint8_t *psel = (uint8_t *)jlrs_genericmemory_typetagdata(m.mem) + i;
-            unsigned nth = 0;
-            // if (!jl_find_union_component(eltype, jl_typeof(rhs), &nth))
-            if (!jlrs_find_union_component(eltype, jl_typeof(rhs), &nth))
-                assert(0 && "invalid genericmemoryset to isbits union");
-            *psel = nth;
-            hasptr = 0;
-            data = (char *)m.mem->ptr + i * layout->size;
-        }
-        else
-        {
-            hasptr = layout->first_ptr >= 0;
-        }
-        if (layout->size != 0)
-        {
-            assert((size_t)(data - (char *)m.mem->ptr) < (size_t)(layout->size * m.mem->length));
-            int needlock = isatomic && layout->size > MAX_ATOMIC_SIZE;
-            size_t fsz = jl_datatype_size((jl_datatype_t *)jl_typeof(rhs)); // need to shrink-wrap the final copy
-            if (isatomic && !needlock)
-            {
-                jl_atomic_store_bits(data, rhs, fsz);
-            }
-            else if (needlock)
-            {
-                // jl_lock_field((jl_mutex_t*)data);
-                // memassign_safe(hasptr, data + LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT), rhs, fsz);
-                // jl_unlock_field((jl_mutex_t*)data);
-                jlrs_lock_nogc((jl_value_t *)data);
-                jlrs_memassign_safe(hasptr, data + LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT), rhs, fsz);
-                jlrs_unlock_nogc((jl_value_t *)data);
-            }
-            else
-            {
-                // memassign_safe(hasptr, data, rhs, fsz);
-                jlrs_memassign_safe(hasptr, data, rhs, fsz);
-            }
-            if (hasptr)
-                jl_gc_multi_wb(jl_genericmemory_owner(m.mem), rhs); // rhs is immutable
-        }
+        assert(jl_memoryrefset_func && "jl_memoryrefset_func not loaded");
+        jl_memoryrefset_func(m, rhs, isatomic);
     }
 
     char *jlrs_genericmemory_typetagdata(jl_genericmemory_t *m)
     {
-        const jl_datatype_layout_t *layout = ((jl_datatype_t *)jl_typetagof(m))->layout;
-        assert(layout->flags.arrayelem_isunion);
-        return (char *)m->ptr + m->length * layout->size;
+        assert(jl_genericmemory_typetagdata_func && "jl_genericmemory_typetagdata_func not loaded");
+        return jl_genericmemory_typetagdata_func(m);
     }
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
@@ -9,66 +9,23 @@ extern "C"
 {
 #endif
 
-    // Enter / exit gc (un)safe region
-    int8_t jlrs_gc_safe_enter(jl_ptls_t ptls);
-    int8_t jlrs_gc_unsafe_enter(jl_ptls_t ptls);
-    void jlrs_gc_safe_leave(jl_ptls_t ptls, int8_t state);
-    void jlrs_gc_unsafe_leave(jl_ptls_t ptls, int8_t state);
+    // There are several functions that are marked as JL_DLLEXPORT but not present in 
+    // jl_exported_funcs.inc. These functions are unavailable in libjulia, but can be found in
+    // libjulia_internal. So, we acquire a handle to that library and load the missing symbols at
+    // runtime.
+    //
+    // This is obviously a hack, but less so than than manually reimplementing these functions. 
+    void jlrs_init_missing_functions(void);
 
 #if JULIA_VERSION_MINOR >= 7
-    // acquire and release lock
-    void jlrs_lock(jl_value_t *v);
-    void jlrs_unlock(jl_value_t *v);
     void jlrs_lock_nogc(jl_value_t *v);
     void jlrs_unlock_nogc(jl_value_t *v);
 #endif // JULIA_VERSION_MINOR >= 7
 
 #if JULIA_VERSION_MINOR >= 11
-    int jlrs_memoryref_isassigned(jl_genericmemoryref_t m, int isatomic);
-    int jlrs_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT;
     jl_genericmemoryref_t jlrs_memoryrefindex(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, size_t idx);
-    char *jlrs_genericmemory_typetagdata(jl_genericmemory_t *m);
     void jlrs_memoryrefset(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, int isatomic);
-
-    static inline void jlrs_memmove_refs(_Atomic(void *) *dstp, _Atomic(void *) *srcp, size_t n) JL_NOTSAFEPOINT
-    {
-        size_t i;
-        if (dstp < srcp || dstp > srcp + n)
-        {
-            for (i = 0; i < n; i++)
-            {
-                jl_atomic_store_release(dstp + i, jl_atomic_load_relaxed(srcp + i));
-            }
-        }
-        else
-        {
-            for (i = 0; i < n; i++)
-            {
-                jl_atomic_store_release(dstp + n - i - 1, jl_atomic_load_relaxed(srcp + n - i - 1));
-            }
-        }
-    }
-
-    static inline void jlrs_memassign_safe(int hasptr, char *dst, const jl_value_t *src, size_t nb) JL_NOTSAFEPOINT
-    {
-        assert(nb == jl_datatype_size(jl_typeof(src)));
-        if (hasptr)
-        {
-            size_t nptr = nb / sizeof(void *);
-            jlrs_memmove_refs((_Atomic(void *) *)dst, (_Atomic(void *) *)src, nptr);
-            nb -= nptr * sizeof(void *);
-            if (__likely(nb == 0))
-                return;
-            src = (jl_value_t *)((char *)src + nptr * sizeof(void *));
-            dst = dst + nptr * sizeof(void *);
-        }
-        else if (nb >= 16)
-        {
-            memcpy(dst, jl_assume_aligned(src, 16), nb);
-            return;
-        }
-        memcpy(dst, jl_assume_aligned(src, sizeof(void *)), nb);
-    }
+    char *jlrs_genericmemory_typetagdata(jl_genericmemory_t *m);
 #endif
 
 #ifdef __cplusplus

--- a/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
@@ -9,12 +9,12 @@ extern "C"
 {
 #endif
 
-    // There are several functions that are marked as JL_DLLEXPORT but not present in 
+    // There are several functions that are marked as JL_DLLEXPORT but not present in
     // jl_exported_funcs.inc. These functions are unavailable in libjulia, but can be found in
     // libjulia_internal. So, we acquire a handle to that library and load the missing symbols at
     // runtime.
     //
-    // This is obviously a hack, but less so than than manually reimplementing these functions. 
+    // This is obviously a hack, but less so than than manually reimplementing these functions.
     void jlrs_init_missing_functions(void);
 
 #if JULIA_VERSION_MINOR >= 7

--- a/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_hacks.h
@@ -18,8 +18,8 @@ extern "C"
     void jlrs_init_missing_functions(void);
 
 #if JULIA_VERSION_MINOR >= 7
-    void jlrs_lock_nogc(jl_value_t *v);
-    void jlrs_unlock_nogc(jl_value_t *v);
+    void jlrs_lock_value(jl_value_t *v);
+    void jlrs_unlock_value(jl_value_t *v);
 #endif // JULIA_VERSION_MINOR >= 7
 
 #if JULIA_VERSION_MINOR >= 11

--- a/jl_sys/src/jlrs_cc/jlrs_cc_reexport.c
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_reexport.c
@@ -48,19 +48,38 @@ extern "C"
     jl_value_t *jlrs_apply(jl_value_t **args, uint32_t nargs) { return jl_apply(args, nargs); }
     jl_task_t *jlrs_current_task()
     {
-        #if JULIA_VERSION_MINOR == 6
+#if JULIA_VERSION_MINOR == 6
         return jl_current_task;
-        #else
-        jl_gcframe_t **pgcstack = jl_get_pgcstack();
-        if (pgcstack == NULL)
-        {
-            return NULL;
-        }
+#else
+    jl_gcframe_t **pgcstack = jl_get_pgcstack();
+    if (pgcstack == NULL)
+    {
+        return NULL;
+    }
 
-        return container_of(pgcstack, jl_task_t, gcstack);
-        #endif
+    return container_of(pgcstack, jl_task_t, gcstack);
+#endif
     }
     const jl_datatype_layout_t *jlrs_datatype_layout(jl_datatype_t *t) { return jl_datatype_layout(t); }
+    int8_t jlrs_gc_safe_enter(jl_ptls_t ptls)
+    {
+        return jl_gc_safe_enter(ptls);
+    }
+
+    int8_t jlrs_gc_unsafe_enter(jl_ptls_t ptls)
+    {
+        return jl_gc_unsafe_enter(ptls);
+    }
+
+    void jlrs_gc_safe_leave(jl_ptls_t ptls, int8_t state)
+    {
+        jl_gc_safe_leave(ptls, state);
+    }
+
+    void jlrs_gc_unsafe_leave(jl_ptls_t ptls, int8_t state)
+    {
+        jl_gc_unsafe_leave(ptls, state);
+    }
 #ifdef __cplusplus
 }
 #endif

--- a/jl_sys/src/jlrs_cc/jlrs_cc_reexport.h
+++ b/jl_sys/src/jlrs_cc/jlrs_cc_reexport.h
@@ -40,6 +40,11 @@ extern "C"
     jl_value_t *jlrs_apply(jl_value_t **args, uint32_t nargs); // X
     jl_task_t *jlrs_current_task();
     const jl_datatype_layout_t *jlrs_datatype_layout(jl_datatype_t *t);
+    int8_t jlrs_gc_safe_enter(jl_ptls_t ptls);
+    int8_t jlrs_gc_unsafe_enter(jl_ptls_t ptls);
+    void jlrs_gc_safe_leave(jl_ptls_t ptls, int8_t state);
+    void jlrs_gc_unsafe_leave(jl_ptls_t ptls, int8_t state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jl_sys/src/lib.rs
+++ b/jl_sys/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bindings;
 pub mod gc_frame;
+pub mod inlined;
 pub mod types;
 
 pub use bindings::*;

--- a/jl_sys/tests/load_missing_functions_test.rs
+++ b/jl_sys/tests/load_missing_functions_test.rs
@@ -1,0 +1,14 @@
+use jl_sys::{jl_atexit_hook, jl_init, jl_is_initialized, jlrs_init_missing_functions};
+
+#[test]
+fn load_missing_functions() {
+    unsafe {
+        jl_init();
+
+        assert!(jl_is_initialized() != 0);
+
+        jlrs_init_missing_functions();
+
+        jl_atexit_hook(0);
+    }
+}

--- a/jlrs/src/data/managed/value/field_accessor.rs
+++ b/jlrs/src/data/managed/value/field_accessor.rs
@@ -8,7 +8,7 @@ use std::{
 
 use jl_sys::jlrs_array_typetagdata;
 #[julia_version(since = "1.7")]
-use jl_sys::{jl_value_t, jlrs_lock_nogc, jlrs_unlock_nogc};
+use jl_sys::{jl_value_t, jlrs_lock_value, jlrs_unlock_value};
 use jlrs_macros::julia_version;
 
 use super::{Value, ValueRef};
@@ -575,7 +575,7 @@ impl<'scope, 'data> FieldAccessor<'scope, 'data> {
                 self.offset = 0;
             }
             _ => {
-                jlrs_lock_nogc(self.value.unwrap().ptr().as_ptr());
+                jlrs_lock_value(self.value.unwrap().ptr().as_ptr());
                 self.state = ViewState::Locked;
             }
         }
@@ -642,7 +642,7 @@ impl<'scope, 'data> FieldAccessor<'scope, 'data> {
             .read();
 
         if locked {
-            jlrs_unlock_nogc(self.value.unwrap().ptr().as_ptr());
+            jlrs_unlock_value(self.value.unwrap().ptr().as_ptr());
             self.state = ViewState::Unlocked;
         }
 
@@ -778,7 +778,7 @@ impl Drop for FieldAccessor<'_, '_> {
         if self.state == ViewState::Locked {
             debug_assert!(!self.value.is_none());
             // Safety: the value is currently locked.
-            unsafe { jlrs_unlock_nogc(self.value.unwrap().ptr().as_ptr()) }
+            unsafe { jlrs_unlock_value(self.value.unwrap().ptr().as_ptr()) }
         }
     }
 }

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -113,25 +113,25 @@
 //! runtime:
 //!
 //!  - `local-rt`
-//!  
+//!
 //!    Enables the local runtime. The local runtime provides single-threaded, blocking access to
 //!    Julia.
-//!  
+//!
 //!  - `async-rt`
-//!  
+//!
 //!    Enables the async runtime. The async runtime runs on a separate thread and can be used from
 //!    multiple threads.
-//!  
+//!
 //!  - `tokio-rt`
-//!  
+//!
 //!    The async runtime requires an executor. This feature provides a tokio-based executor.
-//!  
+//!
 //!  - `multi-rt`
-//!  
+//!
 //!    Enables the multithreaded runtime. The multithreaded runtime lets you call Julia from
 //!    arbitrary threads. It can be combined with the `async-rt` feature to create Julia-aware
 //!    thread pools. This feature requires Julia 1.9 or higher.
-//!  
+//!
 //!
 //! <div class="warning"><strong>WARNING</strong>: Runtime features must only be enabled by applications that embed Julia.
 //! Libraries must never enable a runtime feature.</div>
@@ -521,7 +521,7 @@
 //!
 //!
 //! ### Async runtime
-//!  
+//!
 //! While the sync and multithreaded runtimes let you call into Julia directly from one or more
 //! threads, the async runtime runs on a background thread and uses an executor to allow
 //! running multiple tasks on that thread concurrently. Its handle type, `AsyncHandle`, can be

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -1000,6 +1000,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use jl_sys::jlrs_init_missing_functions;
 #[cfg(feature = "local-rt")]
 use once_cell::sync::OnceCell;
 use prelude::Managed;
@@ -1166,6 +1167,7 @@ pub(crate) unsafe fn init_jlrs(install_jlrs_core: &InstallJlrsCore) {
         return;
     }
 
+    jlrs_init_missing_functions();
     init_foreign_type_registry();
     init_constructed_type_cache();
     init_symbol_cache();


### PR DESCRIPTION
Instead of reimplementing missing functions, let's try to load them at runtime. It seems to work correctly when embedding Julia on Linux, let's see if this works on other platforms and in libraries as well.