### PR TITLE
Fix several issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ are actively tested. Using the current stable version of Julia is highly recomme
 supported Rust version is currently 1.77.
 
 This readme only contains information about what features are supported by jlrs, what
-prerequisites must be met, and how to meet them. For information and examples about how to use
-jlrs, please read the [docs](https://docs.rs/jlrs). The documentation assumes you are already
-familiar with the Julia and Rust programming languages.
+prerequisites must be met, and how to meet them. A complete tutorial is available
+[here](https://taaitaaiger.github.io/jlrs-tutorial/). For more information and examples about how
+to use jlrs, please read the [docs](https://docs.rs/jlrs). All documentation assumes you are
+already familiar with the Julia and Rust programming languages.
 
 
 ## Overview

--- a/jl_sys/Cargo.toml
+++ b/jl_sys/Cargo.toml
@@ -18,13 +18,13 @@ links = "julia"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-julia-1-6 = []
-julia-1-7 = []
-julia-1-8 = []
-julia-1-9 = []
-julia-1-10 = []
-julia-1-11 = []
-julia-1-12 = []
+julia-1-6 = ["jlrs-macros/julia-1-6"]
+julia-1-7 = ["jlrs-macros/julia-1-7"]
+julia-1-8 = ["jlrs-macros/julia-1-8"]
+julia-1-9 = ["jlrs-macros/julia-1-9"]
+julia-1-10 = ["jlrs-macros/julia-1-10"]
+julia-1-11 = ["jlrs-macros/julia-1-11"]
+julia-1-12 = ["jlrs-macros/julia-1-12"]
 
 fast-tls = []
 lto = []
@@ -40,6 +40,7 @@ docs = ["julia-1-12"]
 [build-dependencies]
 cc = "1"
 cfg-if = "1"
+jlrs-macros = { path = "../jlrs_macros", version = "0.4"}
 
 [package.metadata.docs.rs]
 features = ["docs"]

--- a/jlrs/src/data/managed/value/mod.rs
+++ b/jlrs/src/data/managed/value/mod.rs
@@ -85,8 +85,8 @@ macro_rules! named_tuple {
     };
     ($frame:expr, $name:expr => $value:expr, $($rest:tt)+) => {
         {
-            const n: usize = $crate::count!($($rest)+);
-            let mut pairs: [::std::mem::MaybeUninit::<($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value)>; n] = [::std::mem::MaybeUninit::uninit(); n];
+            const N: usize = $crate::count!($($rest)+);
+            let mut pairs: [::std::mem::MaybeUninit::<($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value)>; N] = [::std::mem::MaybeUninit::uninit(); N];
             let name = $crate::convert::to_symbol::ToSymbol::to_symbol(&$name, &$frame);
 
             pairs[0].write((name, $value));
@@ -105,10 +105,10 @@ macro_rules! named_tuple {
             let name = $crate::convert::to_symbol::ToSymbol::to_symbol(&$name, &$frame);
             $pairs[$i].write((name, $value));
 
-            let pairs: &[($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value); n] = unsafe {
+            let pairs: &[($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value); N] = unsafe {
                 ::std::mem::transmute::<
-                    &[::std::mem::MaybeUninit::<($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value)>; n],
-                    &[($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value); n]
+                    &[::std::mem::MaybeUninit::<($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value)>; N],
+                    &[($crate::data::managed::symbol::Symbol, $crate::data::managed::value::Value); N]
                 >($pairs)
             };
 

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -5,6 +5,7 @@
 //! are actively tested. Using the current stable version of Julia is highly recommended. The
 //! minimum supported Rust version is currently 1.77.
 //!
+//! A tutorial is available [here](https://taaitaaiger.github.io/jlrs-tutorial/).
 //!
 //! # Overview
 //!

--- a/jlrs/src/prelude.rs
+++ b/jlrs/src/prelude.rs
@@ -13,7 +13,7 @@ pub use jlrs_macros::{
 
 #[cfg(any(feature = "local-rt", feature = "async-rt", feature = "ccall"))]
 pub use crate::memory::stack_frame::StackFrame;
-#[cfg(any(feature = "async-rt", feature = "local-rt"))]
+#[cfg(any(feature = "async-rt", feature = "local-rt", feature = "multi-rt"))]
 pub use crate::runtime::builder::Builder;
 #[cfg(feature = "tokio-rt")]
 pub use crate::runtime::executor::tokio_exec::*;


### PR DESCRIPTION
- Fix warning when multiple keywords are used.
- Export Builder in prelude if multi-rt is enabled.
- Add references to tutorial.
- Make jl-sys depend on jlrs-macros to improve error message when no version feature is enabled.