### PR TITLE
Async runtime improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 - The `julia-1-6`, `julia-1-7`, `julia-1-8`, and `julia-1-9` features have been removed.
 
-- The async runtime supports using async closures when the `async-closure` feature is enabled. This requires using at least Rust 1.85. The `AsyncTask` trait has been implemented for all async closures `AsyncFnMut(AsyncGcFrame) -> T`, `AsyncHandle::closure` additionally accepts any `AsyncFnOnce(AsyncGcFrame) -> T`. Async closures can also be used in combination with nested async scopes by calling `AsyncGcFrame::async_scope_closure`, which doesn't suffer from the same lifetime issues as `AsyncGcFrame::async_scope`. The methods `AsyncGcFrame::async_scope` and `AsyncGcFrame::relaxed_async_scope` and the feature gate itself will be removed in the future when the MSRV is increased.
+- The `Executor`, `AsyncTask`, and `PersistentTask` traits no longer use `async_trait`. To migrate existing `PersistentTask`s, remove the `async_trait`-annotation. `AsyncTask`s now take `self` by value, so to migrate them remove the annotation and change `&mut self` in `run` to `self`.
+
+- The async runtime supports using async closures when the `async-closure` feature is enabled, this requires using at least Rust 1.85. The `AsyncTask` trait has been implemented for all async closures `AsyncFnOnce(AsyncGcFrame) -> T`, so async closures can easily be called with `AsyncHandle::task`. Async closures can also be used in combination with nested async scopes by calling `AsyncGcFrame::async_scope_closure`, which doesn't suffer from the same lifetime issues as `AsyncGcFrame::async_scope`. The methods `AsyncGcFrame::async_scope` and `AsyncGcFrame::relaxed_async_scope` and the feature gate itself will be removed in the future when the MSRV is increased.
 
 #### v0.21
 

--- a/benches/benches/mt_rt_pool.rs
+++ b/benches/benches/mt_rt_pool.rs
@@ -33,7 +33,6 @@ impl AsyncExecutor for TokioExecutor {
 
 struct MyTask;
 
-#[async_trait(?Send)]
 impl AsyncTask for MyTask {
     type Output = ();
 

--- a/examples/async_tasks.rs
+++ b/examples/async_tasks.rs
@@ -9,14 +9,13 @@ struct MyTask {
     iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MyTask {
     // Different tasks can return different results. If successful, this task returns an `f64`.
     type Output = JlrsResult<f64>;
 
     // This is the async variation of the closure you provide `Julia::scope` when using the sync
     // runtime.
-    async fn run<'frame>(&mut self, mut frame: AsyncGcFrame<'frame>) -> Self::Output {
+    async fn run<'frame>(self, mut frame: AsyncGcFrame<'frame>) -> Self::Output {
         // Convert the two arguments to values Julia can work with.
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
@@ -41,7 +40,6 @@ impl AsyncTask for MyTask {
     }
 }
 
-#[async_trait(?Send)]
 impl Register for MyTask {
     // Include the custom code MyTask needs.
     async fn register<'frame>(mut frame: AsyncGcFrame<'frame>) -> JlrsResult<()> {

--- a/examples/nested_async_scopes.rs
+++ b/examples/nested_async_scopes.rs
@@ -9,17 +9,14 @@ struct MyTask {
     iters: isize,
 }
 
-// `MyTask` is a task we want to be executed, so we need to implement `AsyncTask`. This requires
-// `async_trait` because traits with async methods are not yet available in Rust. Because the
-// task itself is executed on a single thread, it is marked with `?Send`.
-#[async_trait(?Send)]
+// `MyTask` is a task we want to be executed, so we need to implement `AsyncTask`.
 impl AsyncTask for MyTask {
     // Different tasks can return different results. If successful, this task returns an `f64`.
     type Output = JlrsResult<f64>;
 
     // This is the async variation of the closure you provide `Julia::scope` when using the sync
     // runtime.
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         // Nesting async frames works like nesting on ordinary scope. The main difference is that
         // the closure must return an async block.
         let output = frame.output();
@@ -53,7 +50,6 @@ impl AsyncTask for MyTask {
     }
 }
 
-#[async_trait(?Send)]
 impl Register for MyTask {
     // Include the custom code MyTask needs.
     async fn register<'base>(mut frame: AsyncGcFrame<'base>) -> JlrsResult<()> {

--- a/examples/persistent_tasks.rs
+++ b/examples/persistent_tasks.rs
@@ -6,7 +6,6 @@ struct AccumulatorTask {
     init_value: f64,
 }
 
-#[async_trait(?Send)]
 impl Register for AccumulatorTask {
     // Register this task. This method can take care of custom initialization work, in this case
     // creating the mutable MutFloat64 type in the Main module.
@@ -19,7 +18,6 @@ impl Register for AccumulatorTask {
     }
 }
 
-#[async_trait(?Send)]
 impl PersistentTask for AccumulatorTask {
     // The capacity of the channel used to communicate with this task
     const CHANNEL_CAPACITY: usize = 2;

--- a/jlrs/Cargo.toml
+++ b/jlrs/Cargo.toml
@@ -53,7 +53,7 @@ multi-rt = ["jl-sys/fast-tls"]
 # Utilities
 
 # Enable task and channel traits used by the async runtime
-async = ["async-trait", "async-channel"]
+async = ["async-channel"]
 # Enable `ccall` module for use from `ccall`ed Rust functions
 ccall = ["jlrs-macros/ccall"]
 # Enable using `f16` as a layout for `Float16` data
@@ -104,7 +104,6 @@ lock_api = "0.4"
 fnv = "1"
 atomic = "0.6"
 
-async-trait = { version = "0.1", optional = true }
 async-channel = { version = "2", optional = true }
 half = { version = "2.4", optional = true }
 ndarray = { version = "0.16", optional = true }

--- a/jlrs/src/lib.rs
+++ b/jlrs/src/lib.rs
@@ -568,14 +568,13 @@
 //!
 //! // Async tasks must implement the `AsyncTask` trait. Only the runtime thread can call the
 //! // Julia C API, so the `run` method must not return a future that implements `Send` or `Sync`.
-//! #[async_trait(?Send)]
 //! impl AsyncTask for AdditionTask {
 //!     // The type of the result of this task.
 //!     type Output = JlrsResult<u64>;
 //!
 //!     // This async method replaces the closure from the previous examples,
 //!     // an `AsyncGcFrame` can be used the same way as other frame types.
-//!     async fn run<'frame>(&mut self, mut frame: AsyncGcFrame<'frame>) -> Self::Output {
+//!     async fn run<'frame>(self, mut frame: AsyncGcFrame<'frame>) -> Self::Output {
 //!         let a = Value::new(&mut frame, self.a);
 //!         let b = Value::new(&mut frame, self.b);
 //!
@@ -634,7 +633,6 @@
 //! }
 //!
 //! // The same is true for implementations of `PersistentTask`.
-//! #[async_trait(?Send)]
 //! impl PersistentTask for AccumulatorTask {
 //!     type Output = JlrsResult<usize>;
 //!

--- a/jlrs/src/prelude.rs
+++ b/jlrs/src/prelude.rs
@@ -1,7 +1,5 @@
 //! Reexports structs and traits you're likely to need.
 
-#[cfg(feature = "async")]
-pub use async_trait::async_trait;
 #[cfg(feature = "ccall")]
 pub use jlrs_macros::julia_module;
 pub use jlrs_macros::{encode_as_constant_bytes, julia_version};

--- a/jlrs/src/runtime/executor.rs
+++ b/jlrs/src/runtime/executor.rs
@@ -2,8 +2,6 @@
 
 use std::{future::Future, time::Duration};
 
-use async_trait::async_trait;
-
 use super::handle::async_handle::{channel::RecvError, message::Message};
 
 /// Indicates that a task has finished running.
@@ -22,7 +20,6 @@ pub trait IsFinished {
 /// An implementation that uses tokio is avaiable: [`Tokio`].
 ///
 /// [`Tokio`]: crate::runtime::executor::tokio_exec::Tokio
-#[async_trait(?Send)]
 pub trait Executor<const N: usize>: Send + Sync + 'static {
     /// Error that is returned when a task can't be joined because it has panicked.
     ///
@@ -55,7 +52,10 @@ pub trait Executor<const N: usize>: Send + Sync + 'static {
 
     /// Wait on `future` until it resolves or `duration` has elapsed. If the future times out it
     /// must return `None`.
-    async fn timeout<F>(duration: Duration, future: F) -> Option<Result<Message, RecvError>>
+    fn timeout<F>(
+        duration: Duration,
+        future: F,
+    ) -> impl Future<Output = Option<Result<Message, RecvError>>>
     where
         F: Future<Output = Result<Message, RecvError>>;
 }
@@ -120,7 +120,6 @@ pub mod tokio_exec {
         }
     }
 
-    #[async_trait(?Send)]
     impl<const N: usize> Executor<N> for Tokio<N> {
         type JoinError = JoinError;
         type JoinHandle = JoinHandle<()>;

--- a/jlrs/tests/async_util/async_tasks.rs
+++ b/jlrs/tests/async_util/async_tasks.rs
@@ -1,15 +1,18 @@
-use jlrs::{async_util::task::Register, memory::gc::Gc, prelude::*};
+use jlrs::{
+    async_util::task::{AsyncTask, Register},
+    memory::gc::Gc,
+    prelude::*,
+};
 
 pub struct MyTask {
     pub dims: isize,
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MyTask {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -37,11 +40,10 @@ pub struct OtherRetTypeTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for OtherRetTypeTask {
     type Output = f32;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
 
@@ -72,12 +74,10 @@ pub struct KwTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for KwTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("KwTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
         let iters = Value::new(&mut frame, self.iters);
@@ -99,7 +99,6 @@ impl AsyncTask for KwTask {
                 .unwrap()
                 .unbox::<f64>()? as f32
         };
-        // println!("KwTask done");
 
         Ok(v)
     }
@@ -107,12 +106,10 @@ impl AsyncTask for KwTask {
 
 pub struct ThrowingTask;
 
-#[async_trait(?Send)]
 impl AsyncTask for ThrowingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("ThrowingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
 
         let v = unsafe {
@@ -126,7 +123,6 @@ impl AsyncTask for ThrowingTask {
                 .into_jlrs_result()?
                 .unbox::<f64>()? as f32
         };
-        // println!("ThrowingTask done");
 
         Ok(v)
     }
@@ -137,12 +133,10 @@ pub struct NestingTaskAsyncFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
         let iters = Value::new(&mut frame, self.iters);
@@ -168,7 +162,6 @@ impl AsyncTask for NestingTaskAsyncFrame {
             .await?;
 
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
-        // println!("NestingTaskAsyncFrame done");
 
         Ok(v)
     }
@@ -179,19 +172,16 @@ pub struct NestingTaskAsyncValueFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncValueFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncValueFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let output = frame.output();
 
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
 
         let v = (&mut frame)
             .async_scope(|mut frame| async move {
-                // println!("NestingTaskAsyncFrame");
                 let iters = Value::new(&mut frame, self.iters);
 
                 frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
@@ -217,7 +207,6 @@ impl AsyncTask for NestingTaskAsyncValueFrame {
             })
             .await?
             .unbox::<f64>()?;
-        // println!("NestingTaskAsyncValueFrame done");
 
         Ok(v)
     }
@@ -228,12 +217,10 @@ pub struct NestingTaskAsyncCallFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncCallFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncCallFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let output = frame.output();
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
 
@@ -269,7 +256,6 @@ impl AsyncTask for NestingTaskAsyncCallFrame {
             .await?
             .unwrap()
             .unbox::<f64>()?;
-        // println!("NestingTaskAsyncCallFrame done");
 
         Ok(v)
     }
@@ -280,12 +266,10 @@ pub struct NestingTaskAsyncGcFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncGcFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncGcFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         frame.gc_collect_n(jlrs::memory::gc::GcCollection::Full, 3);
         let iters = Value::new(&mut frame, self.iters);
@@ -310,7 +294,6 @@ impl AsyncTask for NestingTaskAsyncGcFrame {
                 }
             })
             .await?;
-        // println!("NestingTaskAsyncGcFrame done");
 
         Ok(v)
     }
@@ -321,12 +304,10 @@ pub struct NestingTaskAsyncDynamicValueFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncDynamicValueFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncDynamicValueFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let output = frame.output();
         let v = frame
             .async_scope(|mut frame| async move {
@@ -350,12 +331,10 @@ impl AsyncTask for NestingTaskAsyncDynamicValueFrame {
                         .unwrap()
                 };
 
-                // println!("Root {out:?}");
                 Ok(out.root(output))
             })
             .await?
             .unbox::<f64>()?;
-        // println!("NestingTaskAsyncDynamicValueFrame done");
 
         Ok(v)
     }
@@ -366,12 +345,10 @@ pub struct NestingTaskAsyncDynamicCallFrame {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for NestingTaskAsyncDynamicCallFrame {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("NestingTaskAsyncDynamicCallFrame {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let output = frame.output();
         let v = frame
             .async_scope(|mut frame| async move {
@@ -416,7 +393,6 @@ impl AsyncTask for NestingTaskAsyncDynamicCallFrame {
             .await?
             .unwrap()
             .unbox::<f64>()?;
-        // println!("NestingTaskAsyncDynamicCallFrame done");
 
         Ok(v)
     }
@@ -426,7 +402,6 @@ pub struct AccumulatorTask {
     pub init_value: f64,
 }
 
-#[async_trait(?Send)]
 impl Register for AccumulatorTask {
     async fn register<'frame>(mut frame: AsyncGcFrame<'frame>) -> JlrsResult<()> {
         unsafe {
@@ -437,7 +412,6 @@ impl Register for AccumulatorTask {
     }
 }
 
-#[async_trait(?Send)]
 impl PersistentTask for AccumulatorTask {
     type State<'state> = Value<'state, 'static>;
     type Input = f64;
@@ -449,7 +423,6 @@ impl PersistentTask for AccumulatorTask {
         &mut self,
         mut frame: AsyncGcFrame<'frame>,
     ) -> JlrsResult<Value<'frame, 'static>> {
-        // println!("AccumulatorTask init {:p}", frame.stack_addr());
         unsafe {
             let output = frame.output();
             let init_value = self.init_value;
@@ -471,7 +444,6 @@ impl PersistentTask for AccumulatorTask {
                 .await?
                 .into_jlrs_result();
 
-            // println!("AccumulatorTask init");
             res
         }
     }
@@ -482,7 +454,6 @@ impl PersistentTask for AccumulatorTask {
         state: &mut Self::State<'state>,
         input: Self::Input,
     ) -> Self::Output {
-        // println!("AccumulatorTask run {:p}", frame.stack_addr());
         let value = state.field_accessor().field("v")?.access::<f64>()? + input;
         let new_value = Value::new(&mut frame, value);
 
@@ -495,7 +466,6 @@ impl PersistentTask for AccumulatorTask {
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
-        // println!("AccumulatorTask run done");
 
         Ok(value)
     }
@@ -506,12 +476,10 @@ pub struct LocalTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for LocalTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("LocalTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -530,7 +498,6 @@ impl AsyncTask for LocalTask {
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
-        // println!("LocalTask done");
 
         Ok(v)
     }
@@ -541,12 +508,10 @@ pub struct LocalSchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for LocalSchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("LocalSchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -570,8 +535,6 @@ impl AsyncTask for LocalSchedulingTask {
                 .unbox::<f64>()? as f32
         };
 
-        // println!("LocalSchedulingTask done");
-
         Ok(v)
     }
 }
@@ -581,12 +544,10 @@ pub struct MainTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MainTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("MainTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -605,7 +566,6 @@ impl AsyncTask for MainTask {
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
         frame.gc_collect(jlrs::memory::gc::GcCollection::Full);
-        // println!("MainTask done");
 
         Ok(v)
     }
@@ -616,12 +576,10 @@ pub struct MainSchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MainSchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("MainSchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -644,7 +602,6 @@ impl AsyncTask for MainSchedulingTask {
                 .into_jlrs_result()?
                 .unbox::<f64>()? as f32
         };
-        // println!("MainSchedulingTask done");
 
         Ok(v)
     }
@@ -655,12 +612,10 @@ pub struct SchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for SchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("SchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -684,7 +639,6 @@ impl AsyncTask for SchedulingTask {
                 .unbox::<f64>()? as f32
         };
 
-        // println!("SchedulingTask done");
         Ok(v)
     }
 }
@@ -694,12 +648,10 @@ pub struct LocalKwSchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for LocalKwSchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("LocalKwSchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -726,7 +678,6 @@ impl AsyncTask for LocalKwSchedulingTask {
                 .into_jlrs_result()?
                 .unbox::<f64>()? as f32
         };
-        // println!("LocalKwSchedulingTask done");
 
         Ok(v)
     }
@@ -737,12 +688,10 @@ pub struct KwSchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for KwSchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("KwSchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -769,7 +718,6 @@ impl AsyncTask for KwSchedulingTask {
                 .into_jlrs_result()?
                 .unbox::<f64>()? as f32
         };
-        // println!("KwSchedulingTask done");
 
         Ok(v)
     }
@@ -780,12 +728,10 @@ pub struct MainKwSchedulingTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MainKwSchedulingTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("MainKwSchedulingTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
 
@@ -812,7 +758,6 @@ impl AsyncTask for MainKwSchedulingTask {
                 .into_jlrs_result()?
                 .unbox::<f64>()? as f32
         };
-        // println!("MainKwSchedulingTask done");
 
         Ok(v)
     }
@@ -823,12 +768,10 @@ pub struct LocalKwTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for LocalKwTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("LocalKwTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
         let kw = Value::new(&mut frame, 5.0f64);
@@ -850,7 +793,6 @@ impl AsyncTask for LocalKwTask {
                 .unwrap()
                 .unbox::<f64>()? as f32
         };
-        // println!("LocalKwTask done");
 
         Ok(v)
     }
@@ -861,12 +803,10 @@ pub struct MainKwTask {
     pub iters: isize,
 }
 
-#[async_trait(?Send)]
 impl AsyncTask for MainKwTask {
     type Output = JlrsResult<f32>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("MainKwTask {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let dims = Value::new(&mut frame, self.dims);
         let iters = Value::new(&mut frame, self.iters);
         let kw = Value::new(&mut frame, 5.0f64);
@@ -888,7 +828,6 @@ impl AsyncTask for MainKwTask {
                 .unwrap()
                 .unbox::<f64>()? as f32
         };
-        // println!("MainKwTask done");
 
         Ok(v)
     }
@@ -896,12 +835,10 @@ impl AsyncTask for MainKwTask {
 
 pub struct BorrowArrayData;
 
-#[async_trait(?Send)]
 impl AsyncTask for BorrowArrayData {
     type Output = JlrsResult<f64>;
 
-    async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-        // println!("BorrowArrayData {:p}", frame.stack_addr());
+    async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
         let mut data = vec![2.0f64];
         let borrowed = &mut data;
         let output = frame.output();
@@ -920,7 +857,6 @@ impl AsyncTask for BorrowArrayData {
         // Uncommenting next line must be compile error
         // let _ = data[0];
         let v = data2[0];
-        // println!("BorrowArrayData done");
         Ok(v)
     }
 }
@@ -931,12 +867,10 @@ impl AsyncTask for BorrowArrayData {
 
 // TODO: Rust 1.85
 // #[cfg(feature = "async-closure")]
-// #[async_trait(?Send)]
 // impl AsyncTask for BorrowArrayDataClosure {
 //     type Output = JlrsResult<f64>;
 
-//     async fn run<'base>(&mut self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
-//         // println!("BorrowArrayData {:p}", frame.stack_addr());
+//     async fn run<'base>(self, mut frame: AsyncGcFrame<'base>) -> Self::Output {
 //         let mut data = vec![2.0f64];
 //         let borrowed = &mut data;
 //         let output = frame.output();
@@ -953,7 +887,6 @@ impl AsyncTask for BorrowArrayData {
 //         // Uncommenting next line must be compile error
 //         // let _ = data[0];
 //         let v = data2[0];
-//         // println!("BorrowArrayData done");
 //         Ok(v)
 //     }
 // }

--- a/jlrs/tests/mt_handle_pool_panic.rs
+++ b/jlrs/tests/mt_handle_pool_panic.rs
@@ -1,7 +1,6 @@
 #[cfg(all(feature = "multi-rt", feature = "async-rt"))]
 mod mt_handle {
 
-    use async_trait::async_trait;
     use jlrs::{
         async_util::task::AsyncTask,
         memory::target::frame::AsyncGcFrame,
@@ -10,11 +9,10 @@ mod mt_handle {
 
     pub struct PanickingTask;
 
-    #[async_trait(?Send)]
     impl AsyncTask for PanickingTask {
         type Output = ();
 
-        async fn run<'base>(&mut self, mut _frame: AsyncGcFrame<'base>) -> Self::Output {
+        async fn run<'base>(self, mut _frame: AsyncGcFrame<'base>) -> Self::Output {
             panic!()
         }
     }


### PR DESCRIPTION
Drop dependency on `async_trait`, let `AsyncTask`s take self by value, treat async closures as `AsyncTask`s