### PR TITLE
Allow specifying julia environment per runtime.

### DIFF
--- a/crates/jlrs/src/lib.rs
+++ b/crates/jlrs/src/lib.rs
@@ -1072,7 +1072,7 @@ impl InstallJlrsCore {
             None => "".to_string(),
             Some(path) => {
                 let str = path.to_str().expect("Environment path is UTF-8.");
-                format!("Pkg.activate({});", str)
+                format!("Pkg.activate(raw\"{}\");", str)
             }
         };
 

--- a/crates/jlrs/src/runtime/builder/mod.rs
+++ b/crates/jlrs/src/runtime/builder/mod.rs
@@ -273,7 +273,9 @@ unsafe fn init_runtime(options: &Builder) {
     unsafe {
         set_n_threads(options);
         init_julia(options);
-        init_jlrs(&options.install_jlrs_core, true);
+
+        let environment = options.environment.as_ref().map(|p| p.as_path());
+        init_jlrs(&options.install_jlrs_core, environment, true);
     }
 }
 


### PR DESCRIPTION
Hi there!

Thanks for `jlrs`, it'll help me a lot to kickstart me in my project! <3

One thing I'd really need is to be able to specify from the rust side what Julia environment Julia code shoud run in. My users should be able to specify in a kind of configuration language Julia scripts to run by the rust program. For each Julia script they should also be able to specify the Julia environment it should run in (multiple scripts could share one environment).

Also, being able to specify environments would prevent `jlrs` from "polluting" the global (or is it user level?) environment with the packages that it needs itself.

This pull request in its current state is more of an attempt to specify clearly what I mean. As it basically contains a custom, hard-coded path, it's not supposed to be merged as is. I just wanted to quick-start a discussion. Because before I go about to "do it properly" I wanted to check with you if:

1. Generally speaking, that's a feature you'd be willing to merge, and
2. Would you be willing to implement it yourself in the not-too-far future, or
3. If should do it, how would you like the option "use this environment" to be propagated up to the client facing API of `jlrs`.

I hope I managed to bring my idea across.

Cheers,
Damian